### PR TITLE
Fix #fetch with options

### DIFF
--- a/lib/rails-brotli-cache/store.rb
+++ b/lib/rails-brotli-cache/store.rb
@@ -130,7 +130,7 @@ module RailsBrotliCache
       return value if value.is_a?(Integer)
       serialized = Marshal.dump(value)
 
-      if serialized.bytesize >= COMPRESS_THRESHOLD && !options.fetch(:compress) == false
+      if serialized.bytesize >= COMPRESS_THRESHOLD && !options.fetch(:compress, true) == false
         compressor = compressor_class(options, default: @compressor_class)
         compressed_payload = compressor.deflate(serialized)
         if compressed_payload.bytesize < serialized.bytesize

--- a/spec/rails-brotli-cache/store_spec.rb
+++ b/spec/rails-brotli-cache/store_spec.rb
@@ -38,6 +38,12 @@ describe RailsBrotliCache do
         expect(cache_store.read("forced-key")).to eq 2
       end
     end
+
+    it "stores value in the configured Rails.cache when options passed" do
+      big_enough_to_compress_value = SecureRandom.hex(2048)
+      cache_store.fetch("test-key", expires_in: 5.seconds) { big_enough_to_compress_value }
+      expect(cache_store.read("test-key")).to eq big_enough_to_compress_value
+    end
   end
 
   describe "#increment and #decrement" do


### PR DESCRIPTION
When calling `Rails.cache.fetch(key, expires_in: 5.seconds) { ... }` the :compress key is not automatically added to the options hash and generates a `KeyError: key not found: :compress`

```
1) RailsBrotliCache#fetch stores value in the configured Rails.cache when options passed
   Failure/Error: if serialized.bytesize >= COMPRESS_THRESHOLD && !options.fetch(:compress) == false

   KeyError:
     key not found: :compress
   # ./lib/rails-brotli-cache/store.rb:133:in `fetch'
   # ./lib/rails-brotli-cache/store.rb:133:in `compressed'
   # ./lib/rails-brotli-cache/store.rb:35:in `block in fetch'
   # ./lib/rails-brotli-cache/store.rb:33:in `fetch'
   # ./spec/rails-brotli-cache/store_spec.rb:44:in `block (3 levels) in <top (required)>'
 ```

the `compress` method should assume we wanted compression unless explicitly said otherwise