### PR TITLE
fix: introduce expected options argument of store.clear method

### DIFF
--- a/lib/rails-brotli-cache/store.rb
+++ b/lib/rails-brotli-cache/store.rb
@@ -124,8 +124,8 @@ module RailsBrotliCache
       @core_store.delete(expanded_cache_key(name), options)
     end
 
-    def clear
-      @core_store.clear
+    def clear(options = {})
+      @core_store.clear(**options)
     end
 
     def increment(name, amount = 1, **options)

--- a/spec/rails-brotli-cache/store_spec.rb
+++ b/spec/rails-brotli-cache/store_spec.rb
@@ -211,4 +211,13 @@ describe RailsBrotliCache do
       expect(cache_store.read("test-key")).to eq nil
     end
   end
+
+  describe "#clear" do
+    it "clears the cache" do
+      expect(cache_store.write("test-key", 1234))
+      expect(cache_store.read("test-key")).to eq 1234
+      cache_store.clear
+      expect(cache_store.read("test-key")).to eq nil
+    end
+  end
 end


### PR DESCRIPTION
According to the documentation, `clear` method is accepting `options` arguments. 
https://api.rubyonrails.org/classes/ActiveSupport/Cache/MemoryStore.html#method-i-clear

With this PR, we will make sure that `clear` method is working as expected.

