### PR TITLE
Remove dependency on `rails`.

### DIFF
--- a/benchmarks/main.rb
+++ b/benchmarks/main.rb
@@ -1,4 +1,5 @@
-require 'rails'
+require "active_support"
+require "active_support/core_ext/hash"
 require 'net/http'
 require 'rails-brotli-cache'
 

--- a/rails-brotli-cache.gemspec
+++ b/rails-brotli-cache.gemspec
@@ -15,9 +15,12 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(spec)/})
   gem.require_paths = ["lib"]
   gem.license       = "MIT"
-  gem.add_dependency "rails"
+  gem.add_dependency "activesupport"
   gem.add_dependency "brotli"
   gem.add_development_dependency "rspec"
+  gem.add_development_dependency "railties"
+  gem.add_development_dependency "activemodel"
+  gem.add_development_dependency "actionpack"
   gem.add_development_dependency "redis"
   gem.add_development_dependency "dalli"
   gem.add_development_dependency "byebug"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'bundler/setup'
-require 'rails'
+require "active_support"
+require "active_support/core_ext/hash"
 require 'redis'
 
 require_relative '../lib/rails-brotli-cache'


### PR DESCRIPTION
Some Rails applications do not depend on all the gems in `rails`, but only on a selected subset. When I tried to use `rails-brotli-cache` in my application I noticed in installed `actionmailbox` and `actiontext` which I do not need, and this library does not need either.

This PR removes the dependency on the whole `rails` package, and leaves only dependency on `activesupport` (and a few other libraries as development dependencies).

I also had to make a few changes to tests and benchmark to make them pass, probably caused by me using Ruby 3.2.2.

Please tell if you'd like me to make any changes. Thanks!