### PR TITLE
Make the fetch_multi behavior fully match default cache store

### DIFF
--- a/lib/rails-brotli-cache/store.rb
+++ b/lib/rails-brotli-cache/store.rb
@@ -116,7 +116,9 @@ module RailsBrotliCache
         *names, options.merge(compress: false)
       ) do |name|
         compressed(yield(name), options)
-      end
+      end.map do |key, val|
+        [source_cache_key(key), uncompressed(val, options)]
+      end.to_h
     end
 
     def exist?(name, options = {})

--- a/lib/rails-brotli-cache/store.rb
+++ b/lib/rails-brotli-cache/store.rb
@@ -115,7 +115,7 @@ module RailsBrotliCache
       @core_store.fetch_multi(
         *names, options.merge(compress: false)
       ) do |name|
-        compressed(yield(name), options)
+        compressed(yield(source_cache_key(name)), options)
       end.map do |key, val|
         [source_cache_key(key), uncompressed(val, options)]
       end.to_h

--- a/spec/rails-brotli-cache/store_spec.rb
+++ b/spec/rails-brotli-cache/store_spec.rb
@@ -112,8 +112,12 @@ describe RailsBrotliCache do
       }
     end
 
-    it "works" do
+    it "works for store and reread" do
       expect(subject).to eq response
+
+      expect(cache_store.fetch_multi(*keys) do |key|
+        big_enough_to_compress_value + key
+      end).to eq response
     end
   end
 

--- a/spec/rails-brotli-cache/store_spec.rb
+++ b/spec/rails-brotli-cache/store_spec.rb
@@ -98,9 +98,22 @@ describe RailsBrotliCache do
   end
 
   describe "fetch_multi" do
+    subject do
+      cache_store.fetch_multi(*keys) do |key|
+        big_enough_to_compress_value + key
+      end
+    end
+
+    let(:keys) { %w[key_1 key_2] }
+    let(:response) do
+      {
+        'key_1' => big_enough_to_compress_value + 'br-key_1',
+        'key_2' => big_enough_to_compress_value + 'br-key_2'
+      }
+    end
+
     it "works" do
-      cache_store.fetch_multi("key_1", "key_2", expires_in: 5.seconds) { big_enough_to_compress_value }
-      expect(cache_store.read("key_1")).to eq big_enough_to_compress_value
+      expect(subject).to eq response
     end
   end
 

--- a/spec/rails-brotli-cache/store_spec.rb
+++ b/spec/rails-brotli-cache/store_spec.rb
@@ -119,6 +119,35 @@ describe RailsBrotliCache do
         big_enough_to_compress_value + key
       end).to eq response
     end
+
+    context 'with a complex object that responds to #cache_key' do
+      subject do
+        cache_store.fetch_multi(*keys) do |key|
+          big_enough_to_compress_value + key.id
+        end
+      end
+
+      let(:keys) do
+        [
+          OpenStruct.new(cache_key: 'key_1', id: '12345'),
+          OpenStruct.new(cache_key: 'key_2', id: '54321')
+        ]
+      end
+      let(:response) do
+        {
+          keys[0] => big_enough_to_compress_value + '12345',
+          keys[1] => big_enough_to_compress_value + '54321'
+        }
+      end
+
+      it "works for store and reread" do
+        expect(subject).to eq response
+
+        expect(cache_store.fetch_multi(*keys) do |key|
+          big_enough_to_compress_value + key.id
+        end).to eq response
+      end
+    end
   end
 
   describe "#increment and #decrement" do

--- a/spec/rails-brotli-cache/store_spec.rb
+++ b/spec/rails-brotli-cache/store_spec.rb
@@ -107,8 +107,8 @@ describe RailsBrotliCache do
     let(:keys) { %w[key_1 key_2] }
     let(:response) do
       {
-        'key_1' => big_enough_to_compress_value + 'br-key_1',
-        'key_2' => big_enough_to_compress_value + 'br-key_2'
+        'key_1' => big_enough_to_compress_value + 'key_1',
+        'key_2' => big_enough_to_compress_value + 'key_2'
       }
     end
 


### PR DESCRIPTION
### Things Done:
- Ensure fetch_multi passes the input name back to the block even if its an object.
- Make the overall behavior of fetch_multi match AR cache fetch_multi