### PR TITLE
feat: implement delete_multi method and add corresponding tests

### DIFF
--- a/lib/rails-brotli-cache/store.rb
+++ b/lib/rails-brotli-cache/store.rb
@@ -89,7 +89,7 @@ module RailsBrotliCache
           expanded_cache_key(key),
           compressed(val, options),
         ]
-      end
+      end.to_h
 
       @core_store.write_multi(
         new_hash,
@@ -105,6 +105,13 @@ module RailsBrotliCache
       core_store.read_multi(*names, options).map do |key, val|
         [source_cache_key(key), uncompressed(val, options)]
       end.to_h
+    end
+
+    def delete_multi(names, options = nil)
+      options = (options || {}).reverse_merge(@init_options)
+      names = names.map { |name| expanded_cache_key(name) }
+
+      core_store.delete_multi(names, options)
     end
 
     def fetch_multi(*names)


### PR DESCRIPTION
Fixes error when calling delete_multi in the cache

```
     Failure/Error: cache_store.delete_multi([[:views, "controller/action", collection1]])
     
     NoMethodError:
       undefined method `[]' for nil
     # ./spec/rails-brotli-cache/store_spec.rb:288:in `block (3 levels) in <top (required)>'
```